### PR TITLE
Limit postal codes

### DIFF
--- a/app/screens/map/mapSelector.js
+++ b/app/screens/map/mapSelector.js
@@ -1,3 +1,4 @@
+import values from 'lodash/values';
 import pickBy from 'lodash/pickBy';
 
 import { createSelector, createStructuredSelector } from 'reselect';
@@ -29,11 +30,33 @@ function postalCodeFilterSelector(state) {
   return state.filters.postalCodes;
 }
 
+const cityUnitsSelector = createSelector(
+  cityFilterSelector,
+  unitsSelector,
+  (city, units) => (
+    city === '' ?
+      values(units) :
+      values(units).filter(unit => unit.city === city)
+  )
+);
+
+const cityUnitPostalCodesSelector = createSelector(
+  cityUnitsSelector,
+  units => units.map(unit => unit.addressZip)
+);
+
+const filteredPostalCodeFilterSelector = createSelector(
+  postalCodeFilterSelector,
+  cityUnitPostalCodesSelector,
+  (selectedPostalCodes, cityPostalCodes) =>
+    selectedPostalCodes.filter(code => cityPostalCodes.indexOf(code) !== -1)
+);
+
 const filteredUnitsSelector = createSelector(
   unitsSelector,
   cityFilterSelector,
   ownerFilterSelector,
-  postalCodeFilterSelector,
+  filteredPostalCodeFilterSelector,
   (units, city, owners, postalCodes) => pickBy(
     units,
     unit => (

--- a/app/screens/map/mapSelector.js
+++ b/app/screens/map/mapSelector.js
@@ -1,7 +1,8 @@
-import values from 'lodash/values';
 import pickBy from 'lodash/pickBy';
 
 import { createSelector, createStructuredSelector } from 'reselect';
+
+import selectors from 'state/selectors';
 
 const images = {
   'AVAIN Asumisoikeus Oy': 'avain',
@@ -14,49 +15,11 @@ const images = {
   'TA-Asumisoikeus Oy': 'ta',
 };
 
-function unitsSelector(state) {
-  return state.data.units;
-}
-
-function cityFilterSelector(state) {
-  return state.filters.city;
-}
-
-function ownerFilterSelector(state) {
-  return state.filters.owners;
-}
-
-function postalCodeFilterSelector(state) {
-  return state.filters.postalCodes;
-}
-
-const cityUnitsSelector = createSelector(
-  cityFilterSelector,
-  unitsSelector,
-  (city, units) => (
-    city === '' ?
-      values(units) :
-      values(units).filter(unit => unit.city === city)
-  )
-);
-
-const cityUnitPostalCodesSelector = createSelector(
-  cityUnitsSelector,
-  units => units.map(unit => unit.addressZip)
-);
-
-const filteredPostalCodeFilterSelector = createSelector(
-  postalCodeFilterSelector,
-  cityUnitPostalCodesSelector,
-  (selectedPostalCodes, cityPostalCodes) =>
-    selectedPostalCodes.filter(code => cityPostalCodes.indexOf(code) !== -1)
-);
-
 const filteredUnitsSelector = createSelector(
-  unitsSelector,
-  cityFilterSelector,
-  ownerFilterSelector,
-  filteredPostalCodeFilterSelector,
+  selectors.unitsSelector,
+  selectors.cityFilterSelector,
+  selectors.ownerFilterSelector,
+  selectors.filteredPostalCodeFilterSelector,
   (units, city, owners, postalCodes) => pickBy(
     units,
     unit => (
@@ -111,13 +74,8 @@ const boundariesSelector = createSelector(
   }
 );
 
-const isLoadedSelector = createSelector(
-  unitsSelector,
-  units => Object.keys(units).length > 0
-);
-
 export default createStructuredSelector({
-  isLoaded: isLoadedSelector,
+  isLoaded: selectors.isLoadedSelector,
   markers: markersSelector,
   boundaries: boundariesSelector,
 });

--- a/app/screens/map/mapSelector.spec.js
+++ b/app/screens/map/mapSelector.spec.js
@@ -128,6 +128,22 @@ describe('screens/map/mapSelector', () => {
       ]);
     });
 
+    it('are only filtered by postal codes that match the selected city', () => {
+      const data = selector(getState({
+        units: {
+          21: createUnit(21, 0, 1, { city: 'Helsinki', addressZip: '00100' }),
+          1: createUnit(1, 2, 3, { city: 'Espoo', addressZip: '02100' }),
+          3: createUnit(3, 2, 3, { city: 'Espoo', addressZip: '02200' }),
+        },
+        city: 'Espoo',
+        postalCodes: ['00100'],
+      }));
+      expect(data.markers).to.deep.equal([
+        { id: '1', latitude: 2, longitude: 3, image: undefined },
+        { id: '3', latitude: 2, longitude: 3, image: undefined },
+      ]);
+    });
+
     it('are filtered by owner', () => {
       const data = selector(getState({
         units: {

--- a/app/screens/map/popup/popupSelector.js
+++ b/app/screens/map/popup/popupSelector.js
@@ -1,17 +1,15 @@
 import { createSelector } from 'reselect';
 
+import selectors from 'state/selectors';
+
 export default function createPopupSelector() {
   function idSelector(state, props) {
     return props.id;
   }
 
-  function unitsSelector(state) {
-    return state.data.units;
-  }
-
   const unitSelector = createSelector(
     idSelector,
-    unitsSelector,
+    selectors.unitsSelector,
     (id, units) => units[id]
   );
 

--- a/app/screens/sidebar/cityFilter/cityFilterSelector.js
+++ b/app/screens/sidebar/cityFilter/cityFilterSelector.js
@@ -1,21 +1,14 @@
-import unique from 'lodash/sortedUniq';
-import values from 'lodash/values';
+import sortedUniq from 'lodash/sortedUniq';
 import { createSelector, createStructuredSelector } from 'reselect';
 
-function unitsSelector(state) {
-  return state.data.units;
-}
-
-function selectedSelctor(state) {
-  return state.filters.city;
-}
+import selectors from 'state/selectors';
 
 const citiesSelector = createSelector(
-  unitsSelector,
-  units => unique(values(units).map(unit => unit.city).sort())
+  selectors.unitsListSelector,
+  units => sortedUniq(units.map(unit => unit.city).sort())
 );
 
 export default createStructuredSelector({
   cities: citiesSelector,
-  selected: selectedSelctor,
+  selected: selectors.cityFilterSelector,
 });

--- a/app/screens/sidebar/ownerFilter/ownerFilterSelector.js
+++ b/app/screens/sidebar/ownerFilter/ownerFilterSelector.js
@@ -1,21 +1,14 @@
 import sortedUniq from 'lodash/sortedUniq';
-import values from 'lodash/values';
 import { createSelector, createStructuredSelector } from 'reselect';
 
-function unitsSelector(state) {
-  return state.data.units;
-}
-
-function selectedOwnersSelector(state) {
-  return state.filters.owners;
-}
+import selectors from 'state/selectors';
 
 const ownersSelector = createSelector(
-  unitsSelector,
-  units => sortedUniq(values(units).map(unit => unit.owner).sort())
+  selectors.unitsListSelector,
+  units => sortedUniq(units.map(unit => unit.owner).sort())
 );
 
 export default createStructuredSelector({
   owners: ownersSelector,
-  selectedOwners: selectedOwnersSelector,
+  selectedOwners: selectors.ownerFilterSelector,
 });

--- a/app/screens/sidebar/postalCodeFilter/postalCodeFilterSelector.js
+++ b/app/screens/sidebar/postalCodeFilter/postalCodeFilterSelector.js
@@ -1,41 +1,8 @@
-import sortedUniq from 'lodash/sortedUniq';
-import values from 'lodash/values';
-import { createSelector, createStructuredSelector } from 'reselect';
+import { createStructuredSelector } from 'reselect';
 
-function unitsSelector(state) {
-  return state.data.units;
-}
-
-function filterSelector(state) {
-  return state.filters.postalCodes;
-}
-
-function cityFilterSelector(state) {
-  return state.filters.city;
-}
-
-const cityUnitsSelector = createSelector(
-  cityFilterSelector,
-  unitsSelector,
-  (city, units) => (
-    city === '' ?
-      values(units) :
-      values(units).filter(unit => unit.city === city)
-  )
-);
-
-const postalCodesSelector = createSelector(
-  cityUnitsSelector,
-  units => sortedUniq(units.map(unit => unit.addressZip).sort())
-);
-
-const filteredFilterSelector = createSelector(
-  filterSelector,
-  postalCodesSelector,
-  (filter, postalCodes) => filter.filter(value => postalCodes.indexOf(value) !== -1)
-);
+import selectors from 'state/selectors';
 
 export default createStructuredSelector({
-  postalCodes: postalCodesSelector,
-  selectedPostalCodes: filteredFilterSelector,
+  postalCodes: selectors.cityUnitPostalCodesSelector,
+  selectedPostalCodes: selectors.filteredPostalCodeFilterSelector,
 });

--- a/app/screens/sidebar/postalCodeFilter/postalCodeFilterSelector.js
+++ b/app/screens/sidebar/postalCodeFilter/postalCodeFilterSelector.js
@@ -10,9 +10,23 @@ function filterSelector(state) {
   return state.filters.postalCodes;
 }
 
-const postalCodesSelector = createSelector(
+function cityFilterSelector(state) {
+  return state.filters.city;
+}
+
+const cityUnitsSelector = createSelector(
+  cityFilterSelector,
   unitsSelector,
-  units => sortedUniq(values(units).map(unit => unit.addressZip).sort())
+  (city, units) => (
+    city === '' ?
+      values(units) :
+      values(units).filter(unit => unit.city === city)
+  )
+);
+
+const postalCodesSelector = createSelector(
+  cityUnitsSelector,
+  units => sortedUniq(units.map(unit => unit.addressZip).sort())
 );
 
 export default createStructuredSelector({

--- a/app/screens/sidebar/postalCodeFilter/postalCodeFilterSelector.js
+++ b/app/screens/sidebar/postalCodeFilter/postalCodeFilterSelector.js
@@ -29,7 +29,13 @@ const postalCodesSelector = createSelector(
   units => sortedUniq(units.map(unit => unit.addressZip).sort())
 );
 
+const filteredFilterSelector = createSelector(
+  filterSelector,
+  postalCodesSelector,
+  (filter, postalCodes) => filter.filter(value => postalCodes.indexOf(value) !== -1)
+);
+
 export default createStructuredSelector({
   postalCodes: postalCodesSelector,
-  selectedPostalCodes: filterSelector,
+  selectedPostalCodes: filteredFilterSelector,
 });

--- a/app/screens/sidebar/postalCodeFilter/postalCodeFilterSelector.spec.js
+++ b/app/screens/sidebar/postalCodeFilter/postalCodeFilterSelector.spec.js
@@ -15,8 +15,27 @@ describe('screens/sidebar/postalCodeFilter/postalCodeSelector', () => {
 
     it('selects postalCodes filter', () => {
       const filter = ['00100', '00200'];
-      const actual = selector(getState({ filter }));
-      expect(actual.selectedPostalCodes).to.equal(filter);
+      const actual = selector(getState({
+        units: {
+          1: { addressZip: '00100', city: 'Helsinki' },
+          2: { addressZip: '00200', city: 'Helsinki' },
+        },
+        filter,
+      }));
+      expect(actual.selectedPostalCodes).to.deep.equal(filter);
+    });
+
+    it('ignores values not in selected city', () => {
+      const actual = selector(getState({
+        units: {
+          1: { addressZip: '00100', city: 'Helsinki' },
+          2: { addressZip: '00120', city: 'Helsinki' },
+          3: { addressZip: '02100', city: 'Espoo' },
+        },
+        city: 'Helsinki',
+        filter: ['00100', '02100'],
+      }));
+      expect(actual.selectedPostalCodes).to.deep.equal(['00100']);
     });
   });
 

--- a/app/screens/sidebar/postalCodeFilter/postalCodeFilterSelector.spec.js
+++ b/app/screens/sidebar/postalCodeFilter/postalCodeFilterSelector.spec.js
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 
 import selector from './postalCodeFilterSelector';
 
-function getState({ units = {}, filter = [] } = {}) {
-  return { data: { units }, filters: { postalCodes: filter } };
+function getState({ units = {}, filter = [], city = '' } = {}) {
+  return { data: { units }, filters: { postalCodes: filter, city } };
 }
 
 describe('screens/sidebar/postalCodeFilter/postalCodeSelector', () => {
@@ -29,6 +29,18 @@ describe('screens/sidebar/postalCodeFilter/postalCodeSelector', () => {
     it('are selected', () => {
       const actual = selector(getState({ units: { 1: { addressZip: '00100' } } }));
       expect(actual.postalCodes).to.deep.equal(['00100']);
+    });
+
+    it('are filtered by city', () => {
+      const actual = selector(getState({
+        units: {
+          1: { addressZip: '00100', city: 'Helsinki' },
+          2: { addressZip: '00120', city: 'Helsinki' },
+          3: { addressZip: '02100', city: 'Espoo' },
+        },
+        city: 'Helsinki',
+      }));
+      expect(actual.postalCodes).to.deep.equal(['00100', '00120']);
     });
 
     it('are sorted', () => {

--- a/app/screens/sidebar/sidebarSelector.js
+++ b/app/screens/sidebar/sidebarSelector.js
@@ -1,8 +1,6 @@
 import { createStructuredSelector } from 'reselect';
 
-function isLoadedSelector(state) {
-  return Object.keys(state.data.units).length > 0;
-}
+import selectors from 'state/selectors';
 
 function isCollapsedSelector(state) {
   return state.ui.sidebar.collapsed;
@@ -10,5 +8,5 @@ function isCollapsedSelector(state) {
 
 export default createStructuredSelector({
   isCollapsed: isCollapsedSelector,
-  isLoaded: isLoadedSelector,
+  isLoaded: selectors.isLoadedSelector,
 });

--- a/app/state/selectors.js
+++ b/app/state/selectors.js
@@ -1,0 +1,59 @@
+import sortedUniq from 'lodash/sortedUniq';
+import values from 'lodash/values';
+import { createSelector } from 'reselect';
+
+function unitsSelector(state) {
+  return state.data.units;
+}
+
+function cityFilterSelector(state) {
+  return state.filters.city;
+}
+
+function ownerFilterSelector(state) {
+  return state.filters.owners;
+}
+
+function postalCodeFilterSelector(state) {
+  return state.filters.postalCodes;
+}
+
+const unitsListSelector = createSelector(
+  unitsSelector,
+  units => values(units)
+);
+
+const isLoadedSelector = createSelector(
+  unitsListSelector,
+  units => Boolean(units.length)
+);
+
+const cityUnitsSelector = createSelector(
+  cityFilterSelector,
+  unitsListSelector,
+  (city, units) => (city === '' ? units : units.filter(unit => unit.city === city))
+);
+
+const cityUnitPostalCodesSelector = createSelector(
+  cityUnitsSelector,
+  units => sortedUniq(units.map(unit => unit.addressZip).sort())
+);
+
+const filteredPostalCodeFilterSelector = createSelector(
+  postalCodeFilterSelector,
+  cityUnitPostalCodesSelector,
+  (selectedPostalCodes, validPostalCodes) =>
+    selectedPostalCodes.filter(code => validPostalCodes.indexOf(code) !== -1)
+);
+
+export default {
+  cityFilterSelector,
+  cityUnitPostalCodesSelector,
+  cityUnitsSelector,
+  filteredPostalCodeFilterSelector,
+  isLoadedSelector,
+  ownerFilterSelector,
+  postalCodeFilterSelector,
+  unitsListSelector,
+  unitsSelector,
+};

--- a/app/state/selectors.spec.js
+++ b/app/state/selectors.spec.js
@@ -1,0 +1,199 @@
+import { expect } from 'chai';
+
+import selectors from './selectors';
+
+function getState(extra) {
+  const units = extra.units || {};
+  const filters = extra.filters || {};
+  const city = filters.city || '';
+  const owners = filters.owners || [];
+  const postalCodes = filters.postalCodes || [];
+  return {
+    data: { units },
+    filters: { city, owners, postalCodes },
+  };
+}
+
+function createUnit(extra) {
+  const defaults = {
+    city: 'Helsinki',
+    coordinates: { longitude: 1, latitude: 2 },
+    id: '1',
+    name: 'Unit name',
+    owner: 'Unit owner',
+    streetAddress: 'Unit address',
+    url: 'http://www.example.com',
+  };
+  return Object.assign(defaults, extra);
+}
+
+describe('state/selectors', () => {
+  describe('unitsSelector', () => {
+    it('returns units', () => {
+      const units = { 3: 1, 4: 0 };
+      const actual = selectors.unitsSelector(getState({ units }));
+      expect(actual).to.equal(units);
+    });
+  });
+
+  describe('cityFilterSelector', () => {
+    it('returns city filter', () => {
+      const city = { some: 'test object' };
+      const actual = selectors.cityFilterSelector(getState({ filters: { city } }));
+      expect(actual).to.equal(city);
+    });
+  });
+
+  describe('ownerFilterSelector', () => {
+    it('returns owner filter', () => {
+      const owners = [1, 2, 3];
+      const actual = selectors.ownerFilterSelector(getState({ filters: { owners } }));
+      expect(actual).to.equal(owners);
+    });
+  });
+
+  describe('postalCodeFilterSelector', () => {
+    it('returns postal code filter', () => {
+      const postalCodes = [1, 2, 3, 4];
+      const actual = selectors.postalCodeFilterSelector(getState({ filters: { postalCodes } }));
+      expect(actual).to.equal(postalCodes);
+    });
+  });
+
+  describe('unitsListSelector', () => {
+    it('returns unit values', () => {
+      const units = { 1: 'a', 2: 'b', 3: 'c' };
+      const actual = selectors.unitsListSelector(getState({ units }));
+      expect(actual.sort()).to.deep.equal(['a', 'b', 'c']);
+    });
+
+    it('returns empty list if no units', () => {
+      const units = {};
+      const actual = selectors.unitsListSelector(getState({ units }));
+      expect(actual).to.deep.equal([]);
+    });
+  });
+
+  describe('isLoadedSelector', () => {
+    it('returns true if units exist', () => {
+      const units = { 1: 'a' };
+      const actual = selectors.isLoadedSelector(getState({ units }));
+      expect(actual).to.be.true;
+    });
+
+    it('returns false if units do not exist', () => {
+      const units = {};
+      const actual = selectors.isLoadedSelector(getState({ units }));
+      expect(actual).to.be.false;
+    });
+  });
+
+  describe('cityUnitsSelector', () => {
+    it('returns empty list if no units', () => {
+      const units = {};
+      const city = 'Helsinki';
+      const actual = selectors.cityUnitsSelector(getState({ units, filters: { city } }));
+      expect(actual).to.deep.equal([]);
+    });
+
+    it('returns empty list if no units in city', () => {
+      const units = { 1: createUnit({ city: 'Espoo' }) };
+      const city = 'Helsinki';
+      const actual = selectors.cityUnitsSelector(getState({ units, filters: { city } }));
+      expect(actual).to.deep.equal([]);
+    });
+
+    it('returns units in city', () => {
+      const unit = createUnit({ city: 'Helsinki' });
+      const units = { 1: unit, 2: createUnit({ id: '2', city: 'Espoo' }) };
+      const city = 'Helsinki';
+      const actual = selectors.cityUnitsSelector(getState({ units, filters: { city } }));
+      expect(actual).to.deep.equal([unit]);
+    });
+  });
+
+  describe('cityUnitPostalCodesSelector', () => {
+    it('returns empty list if no units', () => {
+      const units = {};
+      const city = 'Helsinki';
+      const actual = selectors.cityUnitPostalCodesSelector(getState({ units, filters: { city } }));
+      expect(actual).to.deep.equal([]);
+    });
+
+    it('returns empty list if no units in city', () => {
+      const units = { 1: createUnit({ city: 'Espoo' }) };
+      const city = 'Helsinki';
+      const actual = selectors.cityUnitPostalCodesSelector(getState({ units, filters: { city } }));
+      expect(actual).to.deep.equal([]);
+    });
+
+    it('returns postal codes in city', () => {
+      const units = {
+        1: createUnit({ city: 'Helsinki', addressZip: '00100' }),
+        2: createUnit({ id: '2', city: 'Espoo', addressZip: '02100' }),
+        3: createUnit({ id: '3', city: 'Helsinki', addressZip: '00120' }),
+      };
+      const city = 'Helsinki';
+      const actual = selectors.cityUnitPostalCodesSelector(getState({ units, filters: { city } }));
+      expect(actual).to.deep.equal(['00100', '00120']);
+    });
+
+    it('does not include duplicates and is sorted', () => {
+      const units = {
+        1: createUnit({ city: 'Helsinki', addressZip: '00100' }),
+        2: createUnit({ id: '2', city: 'Helsinki', addressZip: '00120' }),
+        3: createUnit({ id: '3', city: 'Helsinki', addressZip: '00110' }),
+        4: createUnit({ id: '4', city: 'Helsinki', addressZip: '00100' }),
+      };
+      const city = 'Helsinki';
+      const actual = selectors.cityUnitPostalCodesSelector(getState({ units, filters: { city } }));
+      expect(actual).to.deep.equal(['00100', '00110', '00120']);
+    });
+  });
+
+  describe('filteredPostalCodeFilterSelector', () => {
+    it('returns empty list if no units', () => {
+      const units = {};
+      const city = 'Helsinki';
+      const postalCodes = ['00100'];
+      const actual = selectors.filteredPostalCodeFilterSelector(
+        getState({ units, filters: { city, postalCodes } })
+      );
+      expect(actual).to.deep.equal([]);
+    });
+
+    it('returns empty list if no units in city', () => {
+      const units = { 1: createUnit({ city: 'Espoo' }) };
+      const city = 'Helsinki';
+      const postalCodes = ['00100'];
+      const actual = selectors.filteredPostalCodeFilterSelector(
+        getState({ units, filters: { city, postalCodes } })
+      );
+      expect(actual).to.deep.equal([]);
+    });
+
+    it('returns empty list if no units with matching postal code', () => {
+      const units = { 1: createUnit({ city: 'Helsinki', addressZip: '00120' }) };
+      const city = 'Helsinki';
+      const postalCodes = ['00100'];
+      const actual = selectors.filteredPostalCodeFilterSelector(
+        getState({ units, filters: { city, postalCodes } })
+      );
+      expect(actual).to.deep.equal([]);
+    });
+
+    it('returns valid selected postal codes', () => {
+      const units = {
+        1: createUnit({ city: 'Helsinki', addressZip: '00100' }),
+        2: createUnit({ id: '2', city: 'Espoo', addressZip: '02100' }),
+        3: createUnit({ id: '3', city: 'Helsinki', addressZip: '00120' }),
+      };
+      const city = 'Helsinki';
+      const postalCodes = ['00100', '00110', '00120', '02100'];
+      const actual = selectors.filteredPostalCodeFilterSelector(
+        getState({ units, filters: { city, postalCodes } })
+      );
+      expect(actual).to.deep.equal(['00100', '00120']);
+    });
+  });
+});


### PR DESCRIPTION
Closes #44.

There's some cases where I'm not sure how this is supposed to work.

Let's say for example that you select one postal code from Helsinki (00100) and one from Espoo (02100) and the city selection is 'All cities' and then you do one of the following actions:
1. Select city = 'Helsinki'.
2. Select city = 'Kerava'.
3. Select city = 'Helsinki' and then select city = 'All cities'.
4. Select city = 'Helsinki', then add a new postal code from Helsinki (00120) and then select city = 'All cities'.

Which markers should be shown in each of these cases? Here's what is currently shown:
1. Markers matching `city = 'Helsinki' and postalCode = '00100'`.
2. Markers matching `city = 'Kerava'` (no postal code filtering).
3. Markers matching `postalCode in ['00100', '02100']` (includes the Espoo postal code).
4. Markers matching `postalCode in ['00100', '00120']` (does not include the Espoo postal code).

Any thoughts?
